### PR TITLE
Fix snap.install not refreshing resource-delivered snaps after upgrade

### DIFF
--- a/lib/charms/layer/snap.py
+++ b/lib/charms/layer/snap.py
@@ -31,14 +31,12 @@ def install(snapname, **kw):
 
     Sets the snap.installed.{snapname} state.
 
-    If the snap.installed.{snapname} state is already set and
-    the snap options have been changed, then the refresh() function
-    is called.
+    If the snap.installed.{snapname} state is already set then the refresh()
+    function is called.
     '''
     installed_state = 'snap.installed.{}'.format(snapname)
     if reactive.is_state(installed_state):
-        if data_changed('snap.opts.{}'.format(snapname), kw):
-            refresh(snapname, **kw)
+        refresh(snapname, **kw)
     else:
         if hookenv.has_juju_version('2.0'):
             res_path = _resource_get(snapname)
@@ -150,6 +148,9 @@ def _install_store(snapname, **kw):
 
 
 def _refresh_store(snapname, **kw):
+    if not data_changed('snap.opts.{}'.format(snapname), kw):
+        return
+
     cmd = ['snap', 'refresh']
     cmd.extend(_snap_args(**kw))
     cmd.append(snapname)

--- a/reactive/snap.py
+++ b/reactive/snap.py
@@ -33,7 +33,9 @@ from charms.reactive.helpers import data_changed
 def install():
     opts = layer.options('snap')
     for snapname, snap_opts in opts.items():
-        snap.install(snapname, **snap_opts)
+        installed_state = 'snap.installed.{}'.format(snapname)
+        if not reactive.is_state(installed_state):
+            snap.install(snapname, **snap_opts)
     if data_changed('snap.install.opts', opts):
         snap.connect_all()
 


### PR DESCRIPTION
Proposed fix for `snap.install` to handle refreshing resources properly. Needs testing.

Without this, we hit a case where the snaps didn't upgrade after new resources were attached. It went about like this:
1. Initial install, snaps were installed from resources
2. First time attaching a new resource, snap refreshed properly
3. Second time attaching a new resource, no refresh occurred

I think the `data_changed` guard doesn't account for changing resources, so we either need to move the check, or have it look for changes in the resources as well.