### PR TITLE
Remove no_proxy configuration

### DIFF
--- a/reactive/snap.py
+++ b/reactive/snap.py
@@ -108,7 +108,7 @@ def ensure_snapd():
 
 
 def proxy_settings():
-    proxy_vars = ('http_proxy', 'https_proxy', 'no_proxy')
+    proxy_vars = ('http_proxy', 'https_proxy')
     proxy_env = {key: value for key, value in os.environ.items()
                  if key in proxy_vars}
 


### PR DESCRIPTION
Often no_proxy (as used in model-config) includes a few subnets, so as to include all potential VM IPs. Systemd has a limit of 2048 characters. If we place no_proxy in /etc/systemd/system/snapd.service.d/snap_layer_proxy.conf systemd will truncate the variable and skip processing any lines following the no_proxy one. This is reported in https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/413

Removing no_proxy should have no impact since snapd should try to reach any internal services.