### PR TITLE
Fix _refresh_store not working after snap was installed from resource

### DIFF
--- a/lib/charms/layer/snap.py
+++ b/lib/charms/layer/snap.py
@@ -289,7 +289,8 @@ def _refresh_store(snapname, **kw):
     if not data_changed('snap.opts.{}'.format(snapname), kw):
         return
 
-    cmd = ['snap', 'refresh']
+    # --amend allows us to refresh from a local resource
+    cmd = ['snap', 'refresh', '--amend']
     cmd.extend(_snap_args(**kw))
     cmd.append(snapname)
     hookenv.log('Refreshing {} from store'.format(snapname))


### PR DESCRIPTION
Hey @stub42. This fixes an issue I hit after I installed a locally built snap via resource, then attached a zero-byte snap to try to install from the snap store.

Originally seen here: https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/604

Stack trace and `snap refresh` command output:

```
unit-kubernetes-master-0: 11:34:38 ERROR unit.kubernetes-master/0.juju-log Hook error:
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-kubernetes-master-0/.venv/lib/python3.5/site-packages/charms/reactive/__init__.py", line 72, in main
    bus.dispatch(restricted=restricted_mode)
  File "/var/lib/juju/agents/unit-kubernetes-master-0/.venv/lib/python3.5/site-packages/charms/reactive/bus.py", line 382, in dispatch
    _invoke(other_handlers)
  File "/var/lib/juju/agents/unit-kubernetes-master-0/.venv/lib/python3.5/site-packages/charms/reactive/bus.py", line 358, in _invoke
    handler.invoke()
  File "/var/lib/juju/agents/unit-kubernetes-master-0/.venv/lib/python3.5/site-packages/charms/reactive/bus.py", line 180, in invoke
    self._action(*args)
  File "/var/lib/juju/agents/unit-kubernetes-master-0/charm/reactive/kubernetes_master.py", line 270, in do_upgrade
    install_snaps()
  File "/var/lib/juju/agents/unit-kubernetes-master-0/charm/reactive/kubernetes_master.py", line 278, in install_snaps
    snap.install('kubectl', channel=channel, classic=True)
  File "lib/charms/layer/snap.py", line 40, in install
    refresh(snapname, **kw)
  File "lib/charms/layer/snap.py", line 71, in refresh
    _refresh_store(snapname, **kw)
  File "lib/charms/layer/snap.py", line 266, in _refresh_store
    stderr=subprocess.STDOUT)
  File "/usr/lib/python3.5/subprocess.py", line 626, in check_output
    **kwargs).stdout
  File "/usr/lib/python3.5/subprocess.py", line 708, in run
    output=stdout, stderr=stderr)
subprocess.CalledProcessError: Command '['snap', 'refresh', '--channel=1.11/stable', '--classic', 'kubectl']' returned non-zero exit status 1

unit-kubernetes-master-0: 11:34:38 DEBUG unit.kubernetes-master/0.update-status error: local snap "kubectl" is unknown to the store, use --amend to proceed
unit-kubernetes-master-0: 11:34:38 DEBUG unit.kubernetes-master/0.update-status        anyway
```

In my testing, it seems like it's safe to just always pass in `--amend`. If we've previously installed from a local resource, passing in `--amend` forces it to refresh to whatever's in the snap store by the same name. If we've previously installed from the snap store and `snap refresh --amend`, it seems to just follow the standard behavior.