### PR TITLE
Use apt-get over apt for tidier logs

### DIFF
--- a/reactive/snap.py
+++ b/reactive/snap.py
@@ -112,6 +112,7 @@ def ensure_snapd():
     # I don't use the apt layer, because that would tie this layer
     # too closely to apt packaging. Perhaps this is a snap-only system.
     if not shutil.which('snap'):
+        os.environ['DEBIAN_FRONTEND'] = 'noninteractive'
         cmd = ['apt-get', 'install', '-y', 'snapd']
         # LP:1699986: Force install of systemd on Trusty.
         if get_series() == 'trusty':
@@ -122,6 +123,7 @@ def ensure_snapd():
     # on the necessary package and snaps work in lxd xenial containers
     # without the workaround.
     if host.is_container() and not shutil.which('squashfuse'):
+        os.environ['DEBIAN_FRONTEND'] = 'noninteractive'
         cmd = ['apt-get', 'install', '-y', 'squashfuse', 'fuse']
         subprocess.check_call(cmd, universal_newlines=True)
 

--- a/reactive/snap.py
+++ b/reactive/snap.py
@@ -112,7 +112,7 @@ def ensure_snapd():
     # I don't use the apt layer, because that would tie this layer
     # too closely to apt packaging. Perhaps this is a snap-only system.
     if not shutil.which('snap'):
-        cmd = ['apt', 'install', '-y', 'snapd']
+        cmd = ['apt-get', 'install', '-y', 'snapd']
         # LP:1699986: Force install of systemd on Trusty.
         if get_series() == 'trusty':
             cmd.append('systemd')
@@ -122,7 +122,7 @@ def ensure_snapd():
     # on the necessary package and snaps work in lxd xenial containers
     # without the workaround.
     if host.is_container() and not shutil.which('squashfuse'):
-        cmd = ['apt', 'install', '-y', 'squashfuse', 'fuse']
+        cmd = ['apt-get', 'install', '-y', 'squashfuse', 'fuse']
         subprocess.check_call(cmd, universal_newlines=True)
 
 


### PR DESCRIPTION
The apt-get tool is still preferred over apt for use in scripts.

Using apt results in log lines like this, which are not much fun to read:

```
2018-10-03 08:10:41 DEBUG install ^[[s^[[0;0f^[[42m^[[30mProgress: [  0%]^[[49m^[[39m  ^[[uUnpacking libnl-3-200:amd64 (3.2.21-1ubuntu4.1) ...
2018-10-03 08:10:41 DEBUG install ^[[s^[[0;0f^[[42m^[[30mProgress: [  1%]^[[49m^[[39m  ^[[u^[[s^[[0;0f^[[42m^[[30mProgress: [  2%]^[[49m^[[39m  ^[[uSelecting previously unselected package libnl-genl-3-200:amd64.
2018-10-03 08:10:41 DEBUG install Preparing to unpack .../libnl-genl-3-200_3.2.21-1ubuntu4.1_amd64.deb ...
2018-10-03 08:10:41 DEBUG install ^[[s^[[0;0f^[[42m^[[30mProgress: [  3%]^[[49m^[[39m  ^[[uUnpacking libnl-genl-3-200:amd64 (3.2.21-1ubuntu4.1) ...
2018-10-03 08:10:42 DEBUG install ^[[s^[[0;0f^[[42m^[[30mProgress: [  4%]^[[49m^[[39m  ^[[u^[[s^[[0;0f^[[42m^[[30mProgress: [  5%]^[[49m^[[39m  ^[[uSelecting previously unselected package libseccomp2:amd64.
2018-10-03 08:10:42 DEBUG install Preparing to unpack .../libseccomp2_2.1.1-1ubuntu1~trusty4_amd64.deb ...
2018-10-03 08:10:42 DEBUG install ^[[s^[[0;0f^[[42m^[[30mProgress: [  6%]^[[49m^[[39m  ^[[uUnpacking libseccomp2:amd64 (2.1.1-1ubuntu1~trusty4) ...

```