### PR TITLE
Added version and channel lookup functions

### DIFF
--- a/lib/charms/layer/snap.py
+++ b/lib/charms/layer/snap.py
@@ -247,6 +247,32 @@ def get(snapname, key):
 
     return subprocess.check_output(['snap', 'get', snapname, key])
 
+def get_installed_version(snapname):
+    '''Gets the installed version of a snapname.
+       This function will fail if snapname is not an installed snap.
+    '''
+    cmd = ['snap', 'info', snapname]
+    hookenv.log('Get installed key for snap {}'.format(snapname))
+    if not reactive.is_flag_set(get_installed_flag(snapname)):
+        hookenv.log(
+            'Cannot get {} snap installed version because it is not installed'.format(
+                snapname), hookenv.WARNING)
+        return
+    return subprocess.check_output(cmd, encoding='utf-8').partition('installed:')[-1].split()[0]
+
+
+def get_installed_channel(snapname):
+    '''Gets the tracking (channel) of a snapname.
+       This function will fail if snapname is not an installed snap.
+    '''
+    cmd = ['snap', 'info', snapname]
+    hookenv.log('Get channel for snap {}'.format(snapname))
+    if not reactive.is_flag_set(get_installed_flag(snapname)):
+        hookenv.log(
+            'Cannot get snap tracking (channel) because it is not installed'.format(
+                snapname), hookenv.WARNING)
+        return
+    return subprocess.check_output(cmd, encoding='utf-8').partition('tracking:')[-1].split()[0]
 
 def _snap_args(channel='stable', devmode=False, jailmode=False,
                dangerous=False, force_dangerous=False, connect=None,


### PR DESCRIPTION
I've added two functions to make it easier to extract versions from an installed snap.
Its useful if you only install a single snap for your charm.

Like this:

```
@when('snap.installed.pyapp')
@when_not('my.pyapp.application.available')
def set_pyapp_snapped_available():
    version = snap.get_installed_version('pyapp')
    channel = snap.get_installed_channel('pyapp')
    application_version_set(version)
    application_channel_set(channel)
    status_set('active', "Pyapp: {} {}".format(version,channel))
    set_flag('my.pyapp.application.available')
```