### PR TITLE
Install/refresh core snap before other snaps

### DIFF
--- a/reactive/snap.py
+++ b/reactive/snap.py
@@ -16,6 +16,7 @@
 '''
 charms.reactive helpers for dealing with Snap packages.
 '''
+from collections import OrderedDict
 from distutils.version import LooseVersion
 import os.path
 from os import uname
@@ -51,12 +52,19 @@ class InvalidBundleError(Exception):
     pass
 
 
+def sorted_snap_opts():
+    opts = layer.options('snap')
+    opts = sorted(opts.items(), key=lambda item: item[0] != 'core')
+    opts = OrderedDict(opts)
+    return opts
+
+
 def install():
     # Do nothing if we don't have kernel support yet
     if not kernel_supported():
         return
 
-    opts = layer.options('snap')
+    opts = sorted_snap_opts()
     # supported-architectures is EXPERIMENTAL and undocumented.
     # It probably should live in the base layer, blocking the charm
     # during bootstrap if the arch is unsupported.
@@ -82,7 +90,7 @@ def refresh():
     if not kernel_supported():
         return
 
-    opts = layer.options('snap')
+    opts = sorted_snap_opts()
     # supported-architectures is EXPERIMENTAL and undocumented.
     # It probably should live in the base layer, blocking the charm
     # during bootstrap if the arch is unsupported.


### PR DESCRIPTION
Fixes https://github.com/stub42/layer-snap/issues/9

This will allow us to solve a [field critical issue](https://bugs.launchpad.net/charm-kubernetes-worker/+bug/1828063) that affects several charms, while still using the snap layer.yaml options.